### PR TITLE
[ENH] add keyboard control

### DIFF
--- a/games/azur_lane/entry.py
+++ b/games/azur_lane/entry.py
@@ -3,6 +3,7 @@ from util.controller.simulator import Bluestack
 
 if __name__ == '__main__':
     bs = Bluestack("BS_AzurLane")
+    bs.gateway.start()
     task_available = {"1": "FarmChapter", "2": "FarmSubmarineSOS"}
     logger_azurlane.info(f"Available tasks: {task_available}")
 

--- a/games/azur_lane/manager.py
+++ b/games/azur_lane/manager.py
@@ -1,4 +1,7 @@
 import time
+from multiprocessing import SimpleQueue
+
+from pynput import keyboard
 
 from games.azur_lane import logger_azurlane
 from games.azur_lane.interface.scene import SCENES_REGISTERED, SceneUnknown
@@ -15,7 +18,6 @@ class SceneManager:
         self.window = game_window
         self.config = {"interval": 1}
         self.refresher = KillableThread(target=self.refresh_scene)
-        self.refresher.start()
 
     def set_config(self, attribute: str, value):
         self.config[attribute] = value
@@ -57,6 +59,9 @@ class SceneManager:
                 return scene
         return SceneUnknown
 
+    def start(self):
+        self.refresher.start()
+
     def close(self):
         self.refresher.terminate()
 
@@ -76,7 +81,7 @@ class TaskManager:
 
         task = self.TASKS_REGISTERED[task_name](self.game_window)
         executor = KillableThread(target=task.run, name=f"AutoGame[TaskManager]-{task_name}")
-        self.executors[task.name] = executor
+        self.executors[task.name] = (task, executor)
         executor.start()
         task.start()
         return True
@@ -91,28 +96,86 @@ class TaskManager:
         if task_name not in self.executors:
             logger_azurlane.warning(f"Task {task_name} not running.")
             return False
-        self.executors[task_name].terminate()
-        self.executors.pop(task_name)
+
+        task_instance, task_executor = self.executors.pop(task_name)
+        task_executor.terminate()
         return True
 
     def list_task(self):
-        for task_name, task_executor in self.executors.items():
+        for task_name, (task_instance, task_executor) in self.executors.items():
             logger_azurlane.info(f"{task_name} [{'Alive' if task_executor.is_alive() else 'Unknown'}]")
+
+    def get_current_task(self):
+        for task_name, (task_instance, task_executor) in self.executors.items():
+            if task_executor.is_alive():
+                return task_instance, task_executor
+        return None, None
 
     def close(self):
         task_list = list(self.executors.keys())
         for k in task_list:
-            self.executors[k].terminate()
+            _, task_executor = self.executors[k]
+            task_executor.terminate()
             self.executors.pop(k)
+
+
+class InputAdapter:
+    MSG_CAN_RUN_AFTER_BATTLE = 1
+    MSG_CAN_RUN = 2
+
+    def __init__(self, queue):
+        self.queue = queue
+        self.keyboard_listener = keyboard.Listener(on_release=self._on_keyboard_release)
+
+    def _on_keyboard_release(self, key):
+        if key is keyboard.Key.f9:
+            self._put_message(self.MSG_CAN_RUN_AFTER_BATTLE)
+        elif key is keyboard.Key.f10:
+            self._put_message(self.MSG_CAN_RUN)
+
+    def _put_message(self, message):
+        self.queue.put(message)
+
+    def start(self):
+        self.keyboard_listener.start()
+
+    def close(self):
+        self.keyboard_listener.stop()
 
 
 class Gateway:
     def __init__(self, game_window):
+        self.message_queue = SimpleQueue()
+
         self.window = game_window
+        self.input_adapter = InputAdapter(self.message_queue)
         self.task_manager = TaskManager(self.window)
         self.scene_manager = SceneManager(self.window)
+        self.message_handler = KillableThread(target=self.handle_message)
+
+    # consume input messages and change task status
+    def handle_message(self):
+        translation = {
+            self.input_adapter.MSG_CAN_RUN_AFTER_BATTLE: "can_run_after_battle",
+            self.input_adapter.MSG_CAN_RUN: "can_run",
+        }
+        while True:
+            msg = self.message_queue.get()
+            if (msg_trans := translation.get(msg)) is not None:
+                task_instance, _ = self.task_manager.get_current_task()
+                if task_instance is None:
+                    logger_azurlane.info("No task is running currently.")
+                    continue
+                task_instance.reverse(msg_trans)
+
+    def start(self):
+        self.input_adapter.start()
+        self.scene_manager.start()
+        self.message_handler.start()
 
     def close(self):
-        self.task_manager.close()
+        self.input_adapter.close()
         self.scene_manager.close()
+        self.task_manager.close()
+        self.message_handler.terminate()
         logger_azurlane.info("Gateway Terminated.")

--- a/games/azur_lane/task/base.py
+++ b/games/azur_lane/task/base.py
@@ -67,12 +67,14 @@ class BaseTask:
     mkdir = False
 
     state = {}
+    pause_events = (
+        "can_run", "can_run_after_battle"
+    )
     config = ConfigManager()
-    event_handler = PauseEventHandler("can_run")
     logger = logger_azurlane
 
     def __init__(self, window: GameWindow = None):
-        self.event_handler = PauseEventHandler("can_run")
+        self.event_handler = PauseEventHandler(*self.pause_events)
         self.window = window
 
         self.base_dir = f"{DIR_USR_AUTO_GAME_AZURLANE}/{self.name}"
@@ -81,6 +83,9 @@ class BaseTask:
 
     def start(self) -> None:
         self.event_handler.resume()
+
+    def reverse(self, event_names):
+        self.event_handler.reverse(event_names)
 
     @property
     def scene_cur(self):


### PR DESCRIPTION
---
### module `manager`
+ add class `InputAdapter` to support various input sources(currently only support keyboard)
+ class `TaskManager`
  + elements of `executors` property now are Tuple[task_instance, task_executor]
  + add `get_current_task` to get running task instance
+ class `Gateway`
  + now will create a `InputAdapter` instance when initialization
  + use message queue to communicate between different manager instance
  + add `handle_message` method to handle messages from keyboard, and modify task status
  + add `start` method to invoke `input_adapter`, `scene_manager`, `message_handler` thread explicitly ### module `task.base`
+ add `reverse` method, to support reverse task instance pause event status ### module `entry`
+ invoke gateway child thread explicitl